### PR TITLE
Problem: no feedback tracked on what remote access client used

### DIFF
--- a/troposphere/static/js/components/projects/resources/instance/details/actions/InstanceActionsAndLinks.jsx
+++ b/troposphere/static/js/components/projects/resources/instance/details/actions/InstanceActionsAndLinks.jsx
@@ -188,6 +188,8 @@ export default React.createClass({
     onWebDesktop: function(instance, client, protocol) {
         var CSRFToken = findCookie("tropo_csrftoken");
 
+        trackAction(`activated-${client}-${protocol}`);
+
         // build a form to POST to web_desktop
         var form = $("<form>")
             .attr("method", "POST")


### PR DESCRIPTION
Included actions to track when activated

## Description

This is uses the parameters passed to track which _type_ of remote access client/protocol is being used. This will allow us to understand the level of "community" adoption when considering graduating Guacamole from "beta" to a default option.

## Checklist before merging Pull Requests
- ~[ ] New test(s) included to reproduce the bug/verify the feature~
- ~[ ] Documentation created/updated at [Example link to documentation](https://example.test/doc#new_section) to give context to the feature~
- [ ] Reviewed and approved by at least one other contributor.
